### PR TITLE
Issue #6: Add draw compatibility for recent Leaflet version

### DIFF
--- a/js/leaflet-draw-compat.js
+++ b/js/leaflet-draw-compat.js
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Override methods from Leaflet.draw for compatibility with Leaflet 1.9+.
+ *
+ * Prevent deprecation warnings:
+ * "Deprecated use of _flat, please use L.LineUtil.isFlat instead."
+ * Deprecated since 2017, (will be) removed in 2.x.
+ */
+L.Edit.Poly.include({
+  _defaultShape: function () {
+    if (!L.LineUtil.isFlat) {
+      return this._latlngs;
+    }
+    return L.LineUtil.isFlat(this._poly._latlngs) ? this._poly._latlngs : this._poly._latlngs[0];
+  }
+});
+
+L.Edit.PolyVerticesEdit.include({
+  _defaultShape: function () {
+    if (!L.LineUtil.isFlat) {
+      return this._poly._latlngs;
+    }
+    return L.LineUtil.isFlat(this._latlngs) ? this._latlngs : this._latlngs[0];
+  }
+});

--- a/leaflet_widget.module
+++ b/leaflet_widget.module
@@ -307,20 +307,24 @@ function leaflet_widget_process_geojson($geojson) {
  * Implements hook_library_info().
  */
 function leaflet_widget_library_info() {
-  $libraries_path = backdrop_get_path('module', 'leaflet_widget') . '/libraries';
+  $path = backdrop_get_path('module', 'leaflet_widget');
 
   $libraries['Leaflet.draw'] = array(
     'title' => t('Leaflet Draw Library'),
     'version' => '0.4.14',
     'website' => 'https://github.com/Leaflet/Leaflet.draw',
     'js' => array(
-      $libraries_path . '/Leaflet.draw/dist/leaflet.draw-src.js' => array(
+      $path . '/libraries/Leaflet.draw/dist/leaflet.draw.js' => array(
+        'type' => 'file',
+        'group' => JS_LIBRARY,
+      ),
+      $path . '/js/leaflet-draw-compat.js' => array(
         'type' => 'file',
         'group' => JS_LIBRARY,
       ),
     ),
     'css' => array(
-      $libraries_path . '/Leaflet.draw/dist/leaflet.draw.css' => array(
+      $path . '/libraries/Leaflet.draw/dist/leaflet.draw.css' => array(
         'type' => 'file',
         'media' => 'all',
       ),


### PR DESCRIPTION
Fixes #6, prevent deprecation warnings, back to compressed lib (switched by accident), possibly a little more future proof.